### PR TITLE
yoe.conf: Fix SDK_NAME and SDKPATH

### DIFF
--- a/conf/distro/yoe.conf
+++ b/conf/distro/yoe.conf
@@ -9,7 +9,10 @@ SDK_VENDOR = "-yoesdk"
 # Distro version keep it up with Yocto release
 DISTRO_VERSION = "2.6"
 DISTRO_CODENAME = "master"
-SDK_VERSION := "${@'${DISTRO_VERSION}'.replace('snapshot-${DATE}','snapshot')}"
+SDK_VERSION := "${DISTRO_VERSION}"
+
+SDK_NAME = "${DISTRO}-${TCLIBC}-${SDKMACHINE}-${IMAGE_BASENAME}-${TUNE_PKGARCH}-${MACHINE}"
+SDKPATH = "/opt/${DISTRO}/${SDK_VERSION}"
 
 DISTRO_VERSION[vardepsexclude] = "DATE"
 SDK_VERSION[vardepsexclude] = "DATE"


### PR DESCRIPTION
SDKPATH points to /opt much like Poky
SDK_NAME reflects bunch of variables to it can be unique
SDK_VERSION is pinned to simple DISTRO_VERSION

Signed-off-by: Khem Raj <raj.khem@gmail.com>