### PR TITLE
yoe-simple-image: Always include /etc/os-release

### DIFF
--- a/recipes-core/images/yoe-simple-image.bb
+++ b/recipes-core/images/yoe-simple-image.bb
@@ -8,4 +8,8 @@ inherit distro_features_check
 
 IMAGE_FEATURES += "ssh-server-dropbear package-management hwcodecs"
 
+IMAGE_INSTALL += "\
+    os-release \
+"
+
 export IMAGE_BASENAME = "yoe-simple-image"


### PR DESCRIPTION
This is sort of standard file in filesystem now a days
we can use this to deduce several things in image via
editing it using bbappends

Fixes https://github.com/YoeDistro/yoe-distro/issues/64

Signed-off-by: Khem Raj <raj.khem@gmail.com>