### PR TITLE
sama5d27-som1-ek-sd: Reboot after preparing /boot contents

### DIFF
--- a/recipes-support/updater/files/sama5d27-som1-ek-sd/init
+++ b/recipes-support/updater/files/sama5d27-som1-ek-sd/init
@@ -314,6 +314,13 @@ process_update() {
 
   umount $EMMC_BOOT_DEV
 
+
+  if [ -n "$kernel_updated" ]; then
+    msg_splash "kernel updated, rebooting ..."
+    restart
+    sleep 9999d
+  fi
+
   if [ -e $ROOTFS ]; then
     msg_splash "Updating rootfs"
     format_emmc_rootfs

--- a/recipes-support/updater/files/sama5d27-som1-ek-sd/platform
+++ b/recipes-support/updater/files/sama5d27-som1-ek-sd/platform
@@ -5,12 +5,12 @@ KERNEL="zImage at91-sama5d27_som1_ek.dtb"
 BOOT="BOOT.BIN u-boot.bin"
 ROOTFS="rootfs.tar.xz"
 
-EMMC_DEVICE=/dev/mmcblk1
+EMMC_DEVICE=/dev/mmcblk0
 EMMC_BOOT_DEV=${EMMC_DEVICE}p1
 EMMC_ROOTFS_DEV=${EMMC_DEVICE}p2
 EMMC_DATA_DEV=${EMMC_DEVICE}p3
 
-SD_DEVICE=/dev/mmcblk0
+SD_DEVICE=/dev/mmcblk1
 SD_BOOT_DEV=${SD_DEVICE}p1
 SD_ROOTFS_DEV=${SD_DEVICE}p2
 SD_DATA_DEV=${SD_DEVICE}p3


### PR DESCRIPTION
Treat mmcblk0 (full SD slot) as target media for update/install/boot
Use uSD as payload carrier for update image in a FAT partition

Process is as follows

Boot board using sam-ba downloaded at91bootstrap and u-boot into u-boot
shell

SAMBA=/mnt/a/yoe/build/tmp/deploy/images/sama5d27-som1-ek-sd/sam-ba/sam-ba
UBOOT=/mnt/a/yoe/build/tmp/deploy/images/sama5d27-som1-ek-sd/u-boot.bin
BOOTSTRAP=/mnt/a/yoe/build/tmp/deploy/images/sama5d27-som1-ek-sd/at91bootstrap-sama5d27_som1_ek.bin-sam-ba

CLIENT=usb

echo "lowlevel"
${SAMBA} -p ${CLIENT}:ttyACM0 -b sama5d27-som1-ek -t 5 -a lowlevel || exit 1
echo "extram"
${SAMBA} -p ${CLIENT}:ttyACM0 -b sama5d27-som1-ek -t 5 -a extram || exit 1
echo "download bootstrap"
${SAMBA} -p ${CLIENT}:ttyACM0 -b sama5d27-som1-ek -m write:${BOOTSTRAP}:0x200000 || exit 1
echo "download u-boot"
${SAMBA} -p ${CLIENT}:ttyACM0 -b sama5d27-som1-ek -m write:${UBOOT}:0x23F00000 || exit 1
echo "jump to bootstrap"
${SAMBA} -p ${CLIENT}:ttyACM0 -b sama5d27-som1-ek -m execute:0x200000 || exit 1
~/bin/ttyACM0

Insert SD card in SD slot and also update card in uSD slot

Then TFTP kernel+initramfs and DT and boot

setenv serverip 10.0.0.10
setenv ipaddr 10.0.0.126
tftp 0x21000000 at91-sama5d27_som1_ek.dtb
tftp 0x22000000 zImage
bootz 0x22000000 - 0x21000000

This will prepare/partition the SD card and copy content onto /boot
on SD-Card and reboot.

On reboot the system boots from SD slot-1 and then finds that it needs
to update rootfs so it applied the rootfs update from updater image and
boots all the way.

One can reboot the system and this time it will boot into command prompt
using SD in slot-1

Signed-off-by: Khem Raj <raj.khem@gmail.com>