### PR TITLE
Updater: util-linux's sfdisk instead of parted for disk management

### DIFF
--- a/recipes-core/images/initramfs-image.bb
+++ b/recipes-core/images/initramfs-image.bb
@@ -19,10 +19,10 @@ PACKAGE_INSTALL = "\
   mtd-utils-ubifs \
   e2fsprogs \
   e2fsprogs-mke2fs \
-  util-linux-fsck \
   e2fsprogs-e2fsck \
   e2fsprogs-tune2fs \
-  parted \
+  util-linux-fsck \
+  util-linux-sfdisk \
   "
 IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
 inherit core-image
@@ -31,4 +31,3 @@ IMAGE_DEVICE_TABLES = "files/device_table-minimal.txt"
 IMAGE_ROOTFS_SIZE = "8192"
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
 BAD_RECOMMENDATIONS += "busybox-syslog"
-

--- a/recipes-support/updater/files/sama5d27-som1-ek-sd/init
+++ b/recipes-support/updater/files/sama5d27-som1-ek-sd/init
@@ -106,33 +106,14 @@ partition_sd() {
   umount ${DEVICE}p2
   umount ${DEVICE}p3
 
-  DEVICE_SIZE=$(parted -s $DEVICE unit mb print | grep ^Disk | cut -d" " -f 3 | sed -e "s/MB//")
-  if [ "$DEVICE_SIZE" = "" ]; then
-    parted -s $DEVICE mklabel msdos || return 1
-    DEVICE_SIZE=$(parted -s $DEVICE unit mb print | grep ^Disk | cut -d" " -f 3 | sed -e "s/MB//")
-  fi
-
-  ROOTFS_START=$((BOOT_SIZE))
-  ROOTFS_END=$((ROOTFS_START+ROOTFS_SIZE))
-  DATAFS_SIZE=$((DEVICE_SIZE-BOOT_SIZE-ROOTFS_SIZE))
-  DATAFS_START=$((ROOTFS_END))
-  DATAFS_END=$((DATAFS_START+DATAFS_SIZE-4))
-
-  echo "DEVICE_SIZE: $DEVICE_SIZE"
-  echo "ROOTFS_SIZE: $ROOTFS_SIZE"
-  echo "ROOTFS_START: $ROOTFS_START"
-  echo "ROOTFS_END: $ROOTFS_END"
-  echo "DATAFS_SIZE: $DATAFS_SIZE"
-  echo "DATAFS_START: $DATAFS_START"
-  echo "DATAFS_END: $DATAFS_END"
-
   dd if=/dev/zero of=$DEVICE bs=512 count=2 || return 1
-  parted -s $DEVICE mklabel msdos || return 1
-  parted -s $DEVICE mkpart primary 0% $BOOT_SIZE || return 1
-  parted -s $DEVICE set 1 boot on || return 1
-  parted -s $DEVICE mkpart primary $ROOTFS_START $ROOTFS_END || return 1
-  parted -s $DEVICE mkpart primary $DATAFS_START $DATAFS_END || return 1
-
+  # Three primary partitions: one FAT bootable part (boot), second for rootfs and the rest is in third(data)
+  sfdisk $DEVICE << EOF
+  ,${BOOT_SIZE},6,*
+  ,${ROOTFS_SIZE}
+  ;
+EOF
+  sfdisk -V -l $DEVICE
   echo "partitioning $DEVICE done"
   return 0
 }

--- a/recipes-support/updater/files/sama5d27-som1-ek-sd/platform
+++ b/recipes-support/updater/files/sama5d27-som1-ek-sd/platform
@@ -21,9 +21,9 @@ DATA_MOUNT_POINT=/data
 USB_MOUNT_POINT=/media/usb
 SD_MOUNT_POINT=/media/sd
 
-# Size in MB
-BOOT_SIZE=100
-ROOTFS_SIZE=700
+# Size in 'M' for MB, 'G' for GB
+BOOT_SIZE=100M
+ROOTFS_SIZE=700M
 
 FSTYPE=ext4
 BOOT_FSTYPE=vfat


### PR DESCRIPTION
parted was bringing in ~1M along with dependencies into the image
whereas sfdisk is adding < 100K

73     KiB     util-linux-sfdisk

sfdisk partitioning is concise code as can be seem in init script

Signed-off-by: Khem Raj <raj.khem@gmail.com>