### PR TITLE
yoe-simple-image: Do not install udev hwdb

### DIFF
--- a/recipes-core/images/yoe-simple-image.bb
+++ b/recipes-core/images/yoe-simple-image.bb
@@ -61,3 +61,5 @@ do_updater[depends] += "${PN}:do_image_complete"
 do_updater[depends] += "virtual/kernel:do_deploy"
 # We want to build updater everytime we build image
 do_updater[nostamp] = "1"
+
+BAD_RECOMMENDATIONS += "eudev-hwdb"


### PR DESCRIPTION
Saves some space
images/sama5d27_som1_ek_sd/musl/yoe-simple-image/installed-package-sizes.txt
images/sama5d27_som1_ek_sd/musl/yoe-simple-image/installed-package-sizes.txt
@@ -1,4 +1,3 @@
-6134   KiB     eudev-hwdb
 3816   KiB     dt-overlay-at91
 2756   KiB     bluez5
 2504   KiB     shared-mime-info

Signed-off-by: Khem Raj <raj.khem@gmail.com>