### PR TITLE
distro/x11: Remove wayland from distro features

### DIFF
--- a/conf/distro/x11.inc
+++ b/conf/distro/x11.inc
@@ -1,1 +1,2 @@
 DISTRO_FEATURES_append = " x11"
+DISTRO_FEATURES_remove = "wayland"


### PR DESCRIPTION
when distro is supposed to be just X11 then there is no need to have
wayland as competing feature in that distro

Signed-off-by: Khem Raj <raj.khem@gmail.com>