### PR TITLE
yoe-simple-image.bb: Use features_check instead of distro_features_check

### DIFF
--- a/recipes-core/images/yoe-simple-image.bb
+++ b/recipes-core/images/yoe-simple-image.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 DEPENDS += "coreutils-native"
 
-inherit distro_features_check
+inherit features_check
 
 IMAGE_FEATURES += "ssh-server-dropbear package-management hwcodecs"
 


### PR DESCRIPTION
distro_features_check is now deprecated

Signed-off-by: Khem Raj <raj.khem@gmail.com>