### PR TITLE
yoe: Disable uninative on ppc64le build hosts

### DIFF
--- a/conf/distro/yoe.inc
+++ b/conf/distro/yoe.inc
@@ -83,7 +83,7 @@ require conf/distro/include/no-static-libs.inc
 require conf/distro/include/yocto-uninative.inc
 require conf/distro/include/security_flags.inc
 
-INHERIT += "uninative"
+INHERIT += "${@bb.utils.contains('BUILD_ARCH', 'ppc64le', '', 'uninative', d)}"
 
 # Add /etc/build to every image
 INHERIT += "image-buildinfo"


### PR DESCRIPTION
Currently, prebuilt buildtools tarballs for ppc64 do not exist
therefore disable uninative

Signed-off-by: Khem Raj <raj.khem@gmail.com>