### PR TITLE
yoe-debug-image: Revamp

### DIFF
--- a/recipes-core/images/yoe-debug-image.bb
+++ b/recipes-core/images/yoe-debug-image.bb
@@ -59,3 +59,5 @@ IMAGE_INSTALL_append_armv7ve = " cpuburn-arm "
 IMAGE_INSTALL_append_aarch64 = " cpuburn-arm "
 
 export IMAGE_BASENAME = "yoe-debug-image"
+
+QB_MEM = "-m 2048"

--- a/recipes-core/images/yoe-debug-image.bb
+++ b/recipes-core/images/yoe-debug-image.bb
@@ -1,7 +1,7 @@
 # this image includes the base utilities needed to exercise most
 # embedded linux hardware
 
-# note, the following must be set to build netperf:
+# note, the following must be set to build netperf/sox:
 # LICENSE_FLAGS_WHITELIST = "non-commercial"
 # see conf/locallocal.conf.sample in Yoe build template
 
@@ -12,8 +12,9 @@
 #	e2fsprogs-tune2fs \
 #
 require recipes-extended/images/core-image-full-cmdline.bb
+require updater.inc
 
-IMAGE_FEATURES += "package-management hwcodecs"
+IMAGE_FEATURES += "package-management hwcodecs ptest-pkgs tools-debug tools-profile"
 
 IMAGE_INSTALL += "\
 	rsync \
@@ -29,7 +30,6 @@ IMAGE_INSTALL += "\
 	alsa-utils \
 	alsa-utils-alsamixer \
 	alsa-utils-aconnect \
-	alsa-utils-alsaconf \
 	alsa-utils-alsactl \
 	alsa-utils-alsamixer \
 	alsa-utils-amixer \
@@ -37,21 +37,25 @@ IMAGE_INSTALL += "\
 	alsa-utils-aseqdump \
 	alsa-utils-aseqnet \
 	alsa-utils-iecset \
+	alsa-utils-scripts \
 	alsa-utils-speakertest \
 	dosfstools \
 	usbutils \
 	i2c-tools \
+        iw \
 	minicom \
 	screen \
-	wireless-tools \
 	cpufrequtils \
 	nano \
-	cpuburn-neon \
 	sox \
 	strace \
 	ethtool \
-	python \
-	python-pyserial \
+	python3 \
+	python3-pyserial \
 	"
+
+IMAGE_INSTALL_append_armv7a = " cpuburn-arm "
+IMAGE_INSTALL_append_armv7ve = " cpuburn-arm "
+IMAGE_INSTALL_append_aarch64 = " cpuburn-arm "
 
 export IMAGE_BASENAME = "yoe-debug-image"


### PR DESCRIPTION
Add ptest packages, along with profile/debugging tool suite
Rename package to reflect changes in metadata e.g. alsa-utils-alsaconf
is now alsa-utils-scripts etc.

Do not use python2 utilitities, replace with py3

Signed-off-by: Khem Raj <raj.khem@gmail.com>