### PR TITLE
icu: Prune icudata to just include en_US locale data

### DIFF
--- a/recipes-support/icu/icu/filter.json
+++ b/recipes-support/icu/icu/filter.json
@@ -1,0 +1,30 @@
+{
+    "strategy": "additive",
+    "featureFilters": {
+        "brkitr_rules": "include",
+        "brkitr_dictionaries": "include",
+        "brkitr_tree": "include",
+        "coll_tree": "include",
+        "misc": "include",
+        "curr_tree": "include",
+        "lang_tree": "include",
+        "region_tree": "include",
+        "rbnf_tree": "include",
+        "zone_tree": "include",
+        "unit_tree": "include",
+        "cnvalias": "include",
+        "locales_tree": "include",
+        "unames": "include",
+        "ulayout": "include"
+    },
+    "localeFilter": {
+        "filterType": "locale",
+        "includeChildren": false,
+        "whitelist": [
+            "en_US",
+            "en_US_POSIX",
+            "en_001",
+            "en_150"
+        ]
+    }
+}

--- a/recipes-support/icu/icu_%.bbappend
+++ b/recipes-support/icu/icu_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+


### PR DESCRIPTION
Reduces image size for libicudata from 27M to 12M

Signed-off-by: Khem Raj <raj.khem@gmail.com>