### PR TITLE
simpleiot: Disable on all mips

### DIFF
--- a/recipes-siot/simpleiot/simpleiot_git.bb
+++ b/recipes-siot/simpleiot/simpleiot_git.bb
@@ -48,3 +48,6 @@ do_install() {
 }
 
 INSANE_SKIP_${PN} += "ldflags"
+
+COMPATIBLE_HOST_mipsarch = "null"
+


### PR DESCRIPTION
Dependencies like bolt are not yet ported onto mips

errors are like below

../../../../../work-shared/go/pkg/mod/go.etcd.io/bbolt@v1.3.0/bolt_unix.go:62:15: undefined: maxMapSize
../../../../../work-shared/go/pkg/mod/go.etcd.io/bbolt@v1.3.0/db.go:101:13: undefined: maxMapSize
../../../../../work-shared/go/pkg/mod/go.etcd.io/bbolt@v1.3.0/db.go:317:12: undefined: maxMapSize
../../../../../work-shared/go/pkg/mod/go.etcd.io/bbolt@v1.3.0/db.go:335:10: undefined: maxMapSize
../../../../../work-shared/go/pkg/mod/go.etcd.io/bbolt@v1.3.0/db.go:336:8: undefined: maxMapSize
../../../../../work-shared/go/pkg/mod/go.etcd.io/bbolt@v1.3.0/freelist.go:165:19: undefined: maxAllocSize
../../../../../work-shared/go/pkg/mod/go.etcd.io/bbolt@v1.3.0/freelist.go:172:14: undefined: maxAllocSize
../../../../../work-shared/go/pkg/mod/go.etcd.io/bbolt@v1.3.0/freelist.go:200:12: undefined: maxAllocSize
../../../../../work-shared/go/pkg/mod/go.etcd.io/bbolt@v1.3.0/freelist.go:203:7: undefined: maxAllocSize
../../../../../work-shared/go/pkg/mod/go.etcd.io/bbolt@v1.3.0/freelist.go:204:12: undefined: maxAllocSize

Signed-off-by: Khem Raj <raj.khem@gmail.com>