### PR TITLE
icu: Disable parallel build

### DIFF
--- a/recipes-support/icu/icu_%.bbappend
+++ b/recipes-support/icu/icu_%.bbappend
@@ -1,2 +1,4 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
+PARALLEL_MAKE = ""
+


### PR DESCRIPTION
New filter exposes a build race seen occasionally

Item coll/root.res depends on missing item coll/ucadata.icu
Makefile:255: recipe for target 'out/tmp/icudata.lst' failed
make[1]: *** [out/tmp/icudata.lst] Error 2

Signed-off-by: Khem Raj <raj.khem@gmail.com>