### PR TITLE
yoe-simple-image.bb: Add wget to image

### DIFF
--- a/conf/distro/yoe.inc
+++ b/conf/distro/yoe.inc
@@ -170,3 +170,6 @@ PNBLACKLIST[bigbuckbunny-720p] = "big and doesn't really need to be tested so mu
 PNBLACKLIST[tearsofsteel-1080p] = "big and doesn't really need to be tested so much"
 RDEPENDS_packagegroup-meta-multimedia_remove_pn-packagegroup-meta-multimedia = "bigbuckbunny-1080p bigbuckbunny-480p bigbuckbunny-720p tearsofsteel-1080p"
 PNBLACKLIST[build-appliance-image] = "tries to include whole downloads directory in /home/builder/poky :/"
+
+# mask out the old webkitgtk recipes from OE-core
+BBMASK .= "recipes-sato/webkit/webkitgtk"

--- a/recipes-core/images/yoe-release-image.bb
+++ b/recipes-core/images/yoe-release-image.bb
@@ -1,0 +1,8 @@
+# Yoe base image for using feeds
+
+require yoe-simple-image.bb
+
+IMAGE_INSTALL += "\
+    wget \
+"
+export IMAGE_BASENAME = "yoe-release-image"

--- a/recipes-core/images/yoe-sdk-image.bb
+++ b/recipes-core/images/yoe-sdk-image.bb
@@ -6,5 +6,6 @@ require kiosk.inc
 IMAGE_FEATURES += "tools-sdk dev-pkgs"
 
 IMAGE_INSTALL += "packagegroup-go-sdk-target packagegroup-core-buildessential"
+IMAGE_INSTALL_remove_riscv32 = "packagegroup-go-sdk-target"
 
 export IMAGE_BASENAME = "yoe-sdk-image"

--- a/recipes-core/images/yoe-simple-image.bb
+++ b/recipes-core/images/yoe-simple-image.bb
@@ -1,4 +1,4 @@
-# Yoe sample image
+# Yoe base starter image
 
 require recipes-core/images/core-image-base.bb
 require updater.inc


### PR DESCRIPTION
busybox wget lacks TLS handshake, since we use feeds its better to have
secure support in wget, it increases the size a bit but thats perhaps
compromise we are willing to make.

Fixes https://github.com/YoeDistro/yoe-distro/issues/356

Signed-off-by: Khem Raj <raj.khem@gmail.com>